### PR TITLE
Fix for issue https://github.com/minutebase/ember-time-field/issues/7

### DIFF
--- a/addon/states/hours-focused.js
+++ b/addon/states/hours-focused.js
@@ -55,6 +55,21 @@ export default State.extend({
 
   down(manager) {
     manager.get("input").decrementHours();
+  },
+  
+  key(manager, code) {
+    if (!isNumberCode(code)) {
+      return; // no-op
+    }
+
+    const num = keyCodeToNumber(code);
+    manager.get("input").setHours(num);
+
+    if (num <= 2) {
+      manager.transitionTo("digit2");
+    } else {
+      manager.transitionTo("minutes");
+    }
   }
 
 });

--- a/addon/states/minutes-focused.js
+++ b/addon/states/minutes-focused.js
@@ -68,5 +68,20 @@ export default State.extend({
 
   down(manager) {
     manager.get("input").decrementMinutes();
+  },
+
+  key(manager, code) {
+    if (!isNumberCode(code)) {
+      return; // no-op
+    }
+    
+    const num = keyCodeToNumber(code);
+    manager.get("input").setMinutes(num);
+
+    if (num <= 5) {
+      manager.transitionTo("digit2");
+    } else if (manager.get("input.hour12")) {
+      manager.transitionTo("period");
+    }
   }
 });


### PR DESCRIPTION
In latest version 3.0 not able type time using keyboard number keys getting RangeError: Maximum call stack size exceeded 