### PR TITLE
Removed the use of jQuery.

### DIFF
--- a/addon/components/time-field.js
+++ b/addon/components/time-field.js
@@ -292,11 +292,12 @@ export default Component.extend({
 
   updateDOMValue() {
     const value = this.get("_value");
-    this.get("element").value = value;
+    const element = this.get("element");
+    element.value = value;
 
     // trigger standard events in-case anything else is listening
-    this.$().trigger("input");
-    this.$().trigger("change");
+    element.dispatchEvent(new Event("input"));
+    element.dispatchEvent(new Event("change"));
   }
 
 });


### PR DESCRIPTION
There are only two lines of code that is using jQuery and can be refactored to use vanilla JS.

Ember newer versions have the jQuery dependency opt-in and should be disabled as default.